### PR TITLE
Improved the responsiveness of team page

### DIFF
--- a/components/Team.jsx
+++ b/components/Team.jsx
@@ -93,7 +93,7 @@ const TeamSection = () => {
                 <div className='flex flex-wrap justify-evenly items-center mt-12'>
                     {teamData && teamData.map((member) => {
                         return (
-                            <div key={member.id} className="flex flex-col  justify-center items-center gap-4 w-1/4 mb-8">
+                            <div key={member.id} className="flex flex-col justify-center items-center gap-4 w-full sm:w-1/2 md:w-1/4 mb-8">
                                 <div>
                                     <img className='rounded-full border-8 border-yellow-400 aspect-square' src={member.img} alt={member.name} width={175} />
                                 </div>


### PR DESCRIPTION
Have used tailwind css to improve the responsiveness.
Issue assigned to me under #73.

Images :
On mobile :
<img width="365" alt="image" src="https://github.com/gdsc-abesit/GDSC-ABESIT/assets/98284331/dda732a3-aec3-4466-8690-6d218290e2ef">

On Tab :
<img width="560" alt="image" src="https://github.com/gdsc-abesit/GDSC-ABESIT/assets/98284331/395dab41-9ed8-4bc1-976f-83643b8cc2f8">

Kindly merge this PR under hacktoberfest 2023. Thank you