### PR TITLE
Fixed the responsiveness of contributor page

### DIFF
--- a/components/Contributors.jsx
+++ b/components/Contributors.jsx
@@ -40,10 +40,10 @@ function Contributors() {
               {ContributorData &&
                 ContributorData.slice(0, LoadMoreValue).map((member) => {
                   return (
-                    <div key={member.id}>
+                    <div key={member.id} class="scale-75 sm:scale-100">
                       <div className="relative overflow-hidden transition duration-300 transform rounded shadow-lg lg:hover:-translate-y-2 hover:shadow-2xl">
                         <img
-                          className="object-cover w-full h-56 md:h-64 xl:h-80"
+                          className="object-cover w-full sm:h-80"
                           src={member.img}
                           alt={member.name}
                         />


### PR DESCRIPTION
Referring to Issue #91 

So here I've fixed how the images are rendered on the mobile screen. Earlier, the aspect ratio was odd, leading to cropped up images where the faces were not visible right.
<img width="362" alt="image" src="https://github.com/gdsc-abesit/GDSC-ABESIT/assets/98284331/e21a2d6a-2586-4ee8-857f-fb0b90dc1142">

I've now added the transform scaling class in which on mobile screens, the images will be rendered with 75% scaling. Also for the image height to be seen the same on larger screens, I've included the class of h-80.

<img width="362" alt="image" src="https://github.com/gdsc-abesit/GDSC-ABESIT/assets/98284331/798e3551-79b4-43c7-91e1-3d7fc0fa7ffa">

The ui for laptop screen remains the same.

Kindly review this under hacktoberfest 2023. Thank you